### PR TITLE
Fixed typo armaebi to armeabi.

### DIFF
--- a/bmk_config.bmx
+++ b/bmk_config.bmx
@@ -288,10 +288,10 @@ Function Usage:String(fullUsage:Int = False)
 		s:+ "ppc"
 ?arm
 		s:+ "arm"
-?armaebi
-		s:+ "armaebi"
-?armaebiv7a
-		s:+ "armaebiv7a"
+?armeabi
+		s:+ "armeabi"
+?armeabiv7a
+		s:+ "armeabiv7a"
 ?arm64v8a
 		s:+ "arm64v8a"
 ?js
@@ -372,10 +372,10 @@ Function VersionInfo(gcc:String, cores:Int)
 	s:+ "x64"
 ?arm
 	s:+ "arm"
-?armaebi
-	s:+ "armaebi"
-?armaebiv7a
-	s:+ "armaebiv7a"
+?armeabi
+	s:+ "armeabi"
+?armeabiv7a
+	s:+ "armeabiv7a"
 ?arm64v8a
 	s:+ "arm64v8a"
 ?js

--- a/bmk_modutil.bmx
+++ b/bmk_modutil.bmx
@@ -116,8 +116,8 @@ Function ParseSourceFile:TSourceFile( path$ )
 				Case "ppc" cc=processor.CPU()="ppc"
 				Case "x64" cc=processor.CPU()="x64"
 				Case "arm" cc=processor.CPU()="arm"
-				Case "armaebi" cc=processor.CPU()="armaebi"
-				Case "armaebiv7a" cc=processor.CPU()="armaebiv7a"
+				Case "armeabi" cc=processor.CPU()="armeabi"
+				Case "armeabiv7a" cc=processor.CPU()="armeabiv7a"
 				Case "arm64v8a" cc=processor.CPU()="arm64v8a"
 				Case "js" cc=processor.CPU()="js"
 '?
@@ -196,15 +196,15 @@ Function ParseSourceFile:TSourceFile( path$ )
 					If processor.Platform() = "android"
 						 cc=processor.CPU()="arm"
 					End If
-				Case "androidarmaebi"
+				Case "androidarmeabi"
 					cc=False
 					If processor.Platform() = "android"
-						 cc=processor.CPU()="armaebi"
+						 cc=processor.CPU()="armeabi"
 					End If
-				Case "androidarmaebiv7a"
+				Case "androidarmeabiv7a"
 					cc=False
 					If processor.Platform() = "android"
-						 cc=processor.CPU()="armaebiv7a"
+						 cc=processor.CPU()="armeabiv7a"
 					End If
 				Case "androidarm64v8a"
 					cc=False
@@ -339,7 +339,7 @@ Function ValidatePlatformArchitecture()
 				valid = True
 			End If
 		Case "android"
-			If arch = "x86" Or arch = "x64" Or arch = "arm" Or arch = "armeabi"  Or arch = "armaebiv7a"  Or arch = "arm64v8a" Then
+			If arch = "x86" Or arch = "x64" Or arch = "arm" Or arch = "armeabi"  Or arch = "armeabiv7a"  Or arch = "arm64v8a" Then
 				valid = True
 			End If
 		Case "raspberrypi"


### PR DESCRIPTION
bcc has declared arm**bi as "armeabi". On google this is the term most often used.
So I hope i switched those two letters the right way around.