### PR TITLE
FIX: globals.GetRawVar(): Vanilla BMX needs strings instead of objects

### DIFF
--- a/bmk.bmx
+++ b/bmk.bmx
@@ -457,15 +457,15 @@ Rem
 	End If
 End Rem
 	If opt_standalone
-		Local buildScript:String = globals.GetRawVar("EXEPATH") + "/" + StripExt(StripDir( app_main )) + "." + opt_apptype + opt_configmung + processor.CPU() + ".build"
+		Local buildScript:String = string(globals.GetRawVar("EXEPATH")) + "/" + StripExt(StripDir( app_main )) + "." + opt_apptype + opt_configmung + processor.CPU() + ".build"
 		Local ldScript:String = "$APP_ROOT/ld." + processor.AppDet() + ".txt"
 		
 		Local stream:TStream = WriteStream(buildScript)
 		
-		stream.WriteString("echo ~qBuilding " + globals.GetRawVar("OUTFILE") + "...~q~n~n")
+		stream.WriteString("echo ~qBuilding " + string(globals.GetRawVar("OUTFILE")) + "...~q~n~n")
 		
 		stream.WriteString("if [ -z ~q${APP_ROOT}~q ]; then~n")
-		stream.WriteString("~tAPP_ROOT=" + globals.GetRawVar("EXEPATH") + "~n")
+		stream.WriteString("~tAPP_ROOT=" + string(globals.GetRawVar("EXEPATH")) + "~n")
 		stream.WriteString("fi~n~n")
 
 		stream.WriteString("if [ -z ~q${BMX_ROOT}~q ]; then~n")

--- a/bmk_ng.bmx
+++ b/bmk_ng.bmx
@@ -721,7 +721,7 @@ Type TBMK
 	Method FixPaths:String(text:String)
 		Local p:String = text
 		p = p.Replace(BlitzMaxPath()+"/","$BMX_ROOT/")
-		p = p.Replace(globals.GetRawVar("EXEPATH"), "$APP_ROOT")
+		p = p.Replace(string(globals.GetRawVar("EXEPATH")), "$APP_ROOT")
 		Return p
 	End Method
 	

--- a/bmk_util.bmx
+++ b/bmk_util.bmx
@@ -179,7 +179,7 @@ Function LinkApp( path$,lnk_files:TList,makelib,opts$ )
 	Local files$
 	Local tmpfile$=BlitzMaxPath()+"/tmp/ld.tmp"
 	
-	If opt_standalone tmpfile = globals.GetRawVar("EXEPATH") + "/ld." + processor.AppDet() + ".txt.tmp"
+	If opt_standalone tmpfile = string(globals.GetRawVar("EXEPATH")) + "/ld." + processor.AppDet() + ".txt.tmp"
 	
 	If processor.Platform() = "macos"
 		cmd="g++"


### PR DESCRIPTION
Vanilla-BCC does not allow concatenating __objects__ and __strings__. Also autocasting is not possible (str.Replace(obj, string)).

The other option is to return "string" by default with GetRawVar() - or create an "GetRawVarString()"-method.

