### PR TITLE
Fix processpragmas

### DIFF
--- a/bmk.bmx
+++ b/bmk.bmx
@@ -108,7 +108,6 @@ Case "makelib"
 	MakeApplication args,True
 Case "makemods"
 	opt_quickscan = False
-	opt_modbuild = True
 	If opt_debug Or opt_release
 		SetConfigMung
 		MakeModules args

--- a/bmk_config.bmx
+++ b/bmk_config.bmx
@@ -10,7 +10,6 @@ Const BMK_VERSION:String = "3.04"
 
 Const ALL_SRC_EXTS$="bmx;i;c;m;h;cpp;cxx;mm;hpp;hxx;s;cc"
 
-Global opt_modbuild
 Global opt_arch$
 Global opt_server$
 Global opt_outfile$

--- a/bmk_make.bmx
+++ b/bmk_make.bmx
@@ -360,6 +360,10 @@ Type TBuildManager
 					Throw "Unable to create temporary directory"
 				End If
 
+				' change dir, so relative commands work as expected
+				' (eg. file processing in BMK-scripts called via pragma)
+				ChangeDir ExtractDir( m.path )
+
 				' bmx file
 				If Match(m.ext, "bmx") Then
 				
@@ -373,7 +377,14 @@ Type TBuildManager
 								If Not opt_quiet Then
 									Print ShowPct(m.pct) + "Processing:" + StripDir(m.path)
 								End If
-								
+
+								' process pragmas
+								Local pragma_inDefine:Int, pragma_text:String, pragma_name:String		
+								For Local pragma:String = EachIn m.pragmas
+									processor.ProcessPragma(pragma, pragma_inDefine, pragma_text, pragma_name)		
+									print "~nprocessing pragma: "+pragma+"  text: "+pragma_text +"  name: "+pragma_name
+								Next
+													
 								CompileBMX m.path, m.obj_path, m.bcc_opts
 	
 								m.iface_time = time_(Null)


### PR DESCRIPTION
The attached patch reintroduces pragma-processing (`'@bmk dosomething(bla)`) and readds the "ChangeDir()"-command before processing files (needed for the BMK/Lua-Scripts to work with files in a project)