### PR TITLE
Fix: corrected ExtractExt()-command, re-enables compilation of bmk

### DIFF
--- a/bmk_modutil.bmx
+++ b/bmk_modutil.bmx
@@ -135,7 +135,7 @@ Type TSourceFile
 		If ext = "o" Then
 			Local file:String = StripExt(o_path)
 			Local fp:String = StripExt(file)
-			Select file.ExtractExt(file)
+			Select ExtractExt(file)
 				Case "arm64"
 					fp :+ ".armv7.o"
 				Case "armv7"


### PR DESCRIPTION
Closes bmx-ng/bmk#14