### PR TITLE
Fix: SIMD "SSE4" is not available on AMD CPUs. Lower it to SSE3.

### DIFF
--- a/make.bmk
+++ b/make.bmk
@@ -419,7 +419,7 @@
 	globals.SetOption("cc_opts", "linker", "-c")
 	globals.SetOption("cc_opts", "optimization", "-O3")
 	if bmk.CPU() == "x64" then
-		globals.SetOption("cc_opts", "simd", "-msse4")
+		globals.SetOption("cc_opts", "simd", "-msse3")
 	end
 	
 	if bmk.IsDebugBuild() == 0 then


### PR DESCRIPTION
Newer AMD CPUs support SSE4.1, SSE4.2 and SSE4a but all AMD CPUs do not support SSE4. Intel Supports SSE4 but not SSE4a. So we need to fall back to gcc option "MSSE3" which CPUs from 2004 (Intel) and 2005 (AMD) should support.

Fixes bmx-ng/bmk/issues/29