### PR TITLE
[Feature] Expose some more opt_*-globals to BMK-scripts (bmk.*)

### DIFF
--- a/bmk_ng.bmx
+++ b/bmk_ng.bmx
@@ -739,6 +739,30 @@ Type TBMK
 		Return opt_debug
 	End Method
 
+	Method IsReleaseBuild:Int()
+		Return opt_release
+	End Method
+
+	Method IsThreadedBuild:Int()
+		Return opt_threaded
+	End Method
+
+	Method IsQuickscanBuild:Int()
+		Return opt_quickscan
+	End Method
+
+	Method IsUniversalBuild:Int()
+		Return opt_universal
+	End Method
+
+	Method GetModFilter:String()
+		return opt_modfilter
+	End Method
+
+	Method GetConfigMung:String()
+		return opt_configmung
+	End Method
+
 	Method RunCommand:Object(command:String, args:String[])
 		Local cmd:TBMKCommand = TBMKCommand(commands.ValueForKey(command.ToLower()))
 		If cmd Then


### PR DESCRIPTION
In reference to the comments in 69b46459afed4332e358950c492213078168380c I exposed some more `opt_***` globals. Another option would be to use `globals.setVar(name, value)` but as there was an `IsDebugBuild` I think it should have some other "build options" exposed too.