### PR TITLE
Removed hard-coded file-path to '/bin/cat'

### DIFF
--- a/bmk_cores_linux.bmx
+++ b/bmk_cores_linux.bmx
@@ -16,9 +16,9 @@ Function GetCoreCount:Int()
 	If Not count Then
 		Local buf:Byte[128]
 ?bmxng
-		Local fp:Byte Ptr = popen("/bin/cat /proc/cpuinfo |grep -c '^processor'", "r")
+		Local fp:Byte Ptr = popen("cat /proc/cpuinfo |grep -c '^processor'", "r")
 ?Not bmxng
-		Local fp:Int = popen("/bin/cat /proc/cpuinfo |grep -c '^processor'", "r")
+		Local fp:Int = popen("cat /proc/cpuinfo |grep -c '^processor'", "r")
 ?
 		fread_(buf, 1, 127, fp)
 		fclose_(fp)


### PR DESCRIPTION
Changed it to just 'cat'.

Since the call to `grep` isn't hardcoded to a path, I think it would be acceptable (and is more flexible) to also not hard-code a path to `cat`. This is causing me issues in trying to run `bmk` to compile a game.