### PR TITLE
Fix: Correct pre/post processing script names

### DIFF
--- a/bmk.bmx
+++ b/bmk.bmx
@@ -307,7 +307,7 @@ Function MakeApplication( args$[],makelib:Int,compileOnly:Int = False )
 	LoadBMK(ExtractDir(Main) + "/pre.bmk")
 
 	' project-specific pre process
-	LoadBMK(ExtractDir(Main) + "/" + StripDir( opt_outfile ) + ".bmk")
+	LoadBMK(ExtractDir(Main) + "/" + StripDir( opt_outfile ) + ".pre.bmk")
 
 	If processor.Platform() = "win32" Then
 		If makelib

--- a/bmk_make.bmx
+++ b/bmk_make.bmx
@@ -755,8 +755,11 @@ Type TBuildManager Extends TCallback
 	
 		If app_build Then
 
-			' post process
+			' generic post process
 			LoadBMK(ExtractDir(app_main) + "/post.bmk")
+
+			' project-specific post process
+			LoadBMK(ExtractDir(app_main) + "/" + StripDir( opt_outfile ) + ".post.bmk")
 
 			Select processor.Platform()
 			Case "android"


### PR DESCRIPTION
Before: BMK used "pre.bmk" for generic pre process and "binaryname.bmk"
for specific pre processing. For post processing only "post.bmk" was
used.

Now: "pre.bmk" and "post.bmk" build the generics while
"binaryname.pre.bmk" and "binaryname.post.bmk" are project specific.