### PR TITLE
Show more of the source file path being compiled

### DIFF
--- a/bmk_make.bmx
+++ b/bmk_make.bmx
@@ -535,7 +535,7 @@ Type TBuildManager Extends TCallback
 							If m.requiresBuild Or (m.time > m.gen_time Or m.iface_time < m.MaxIfaceTime() Or Not m.MaxIfaceTime()) Then
 
 								If Not opt_quiet Then
-									Print ShowPct(m.pct) + "Processing:" + StripDir(m.path)
+									Print ShowPct(m.pct) + "Processing:" + ShortenFilepath(m.path)
 								End If
 
 								' process pragmas
@@ -583,7 +583,7 @@ Type TBuildManager Extends TCallback
 									Local cobj_path:String = StripExt(m.obj_path) + ".o"
 
 									If Not opt_quiet Then
-										Local s:String = ShowPct(m.pct) + "Compiling:" + StripDir(csrc_path)
+										Local s:String = ShowPct(m.pct) + "Compiling:" + ShortenFilepath(csrc_path)
 										If opt_standalone And Not opt_nolog processor.PushEcho(FixPct(s))
 										Print s
 									End If
@@ -601,7 +601,7 @@ Type TBuildManager Extends TCallback
 									Local obj_path:String = StripExt(m.obj_path) + ".o"
 
 									If Not opt_quiet Then
-										Print ShowPct(m.pct) + "Compiling:" + StripDir(src_path)
+										Print ShowPct(m.pct) + "Compiling:" + ShortenFilepath(src_path)
 									End If
 
 									Assemble src_path, obj_path
@@ -620,7 +620,7 @@ Type TBuildManager Extends TCallback
 								m.GetObjs(objs)
 	
 								If Not opt_quiet Then
-									Local s:String = ShowPct(m.pct) + "Archiving:" + StripDir(m.arc_path)
+									Local s:String = ShowPct(m.pct) + "Archiving:" + ShortenFilepath(m.arc_path)
 									If opt_standalone And Not opt_nolog processor.PushEcho(FixPct(s))
 									Print s
 								End If
@@ -736,7 +736,7 @@ Type TBuildManager Extends TCallback
 					If m.requiresBuild Then
 
 						If Not opt_quiet Then
-							Local s:String = ShowPct(m.pct) + "Compiling:" + StripDir(m.path)
+							Local s:String = ShowPct(m.pct) + "Compiling:" + ShortenFilepath(m.path)
 							If opt_standalone And Not opt_nolog processor.PushEcho(FixPct(s))
 							Print s
 						End If
@@ -760,7 +760,7 @@ Type TBuildManager Extends TCallback
 						If m.requiresBuild Then
 	
 							If Not opt_quiet Then
-								Local s:String = ShowPct(m.pct) + "Compiling:" + StripDir(m.path)
+								Local s:String = ShowPct(m.pct) + "Compiling:" + ShortenFilepath(m.path)
 								If opt_standalone And Not opt_nolog processor.PushEcho(FixPct(s))
 								Print s
 							End If

--- a/bmk_util.bmx
+++ b/bmk_util.bmx
@@ -11,6 +11,26 @@ Const USE_NASM:Int=False
 Const CC_WARNINGS:Int=False'True
 Const IOS_HAS_MERGE:Int = False
 
+Function ShortenFilepath:String(Filepath:String)
+	Local FilepathLength:Int = Filepath.Length
+
+	Local Index:Int = 0, Count:Int = 0
+	For Index = FilepathLength To 1 Step -1
+		If Filepath[Index] = Asc("/") Or Filepath[Index] = Asc("\")..
+			Count :+1
+
+		If Count = 2
+			If Filepath[Index..Index + 5] = "/.bmx"..
+				Count = 1
+		EndIf
+
+		If Count = 2..
+			Exit
+	Next
+
+	Return ".." + Filepath[Index..]
+EndFunction
+
 Type TModOpt ' BaH
 	Field cc_opts:String = ""
 	Field ld_opts:TList = New TList


### PR DESCRIPTION
Hi,

This PR is very minor. It includes the parent folder of the current file that's being compiled. Due to some source files have the same name but in different modules and folders it would have always been nice to see what folder the source file relates to. If the parent folder is '.bmx' then the parent of that folder is included too.

An simple example would be that the original output of bmk would show just the file name of the current compilation:
```
[ 21%] Processing:main.bmx
[ 85%] Compiling:main.bmx.gui.debug.macos.arm64.c
[100%] Linking:main.debug
```

and with this PR the output becomes
```
[ 21%] Processing:../Examples/main.bmx
[ 85%] Compiling:../Examples/.bmx/main.bmx.gui.debug.macos.arm64.c
[100%] Linking:main.debug
```