### PR TITLE
Fix: Correct no-exceptions removal for cc_opts and opts

### DIFF
--- a/make.bmk
+++ b/make.bmk
@@ -274,14 +274,8 @@
 
 	# Remove -fno-exceptions if we have provided -fexceptions
 	local cc_opts = %cc_opts%
-
-	if cc_opts:find("-fexceptions") ~= nil then
-		cc_opts = cc_opts:gsub("%-fno%-exceptions", print)
-	end
-
-	if opts:find("-fexceptions") ~= nil then
-		cc_opts = cc_opts:gsub("%-fno%-exceptions", "")
-	end
+	cc_opts = cc_opts:gsub("%-fno%-exceptions", "")
+	opts = opts:gsub("%-fno%-exceptions", "")
 
 	cmd = cmd .. opts .. cc_opts .. %mod_ccopts% .. genDebug .. " -o " .. bmk.Quote(obj) .. " " .. bmk.Quote(src)
 


### PR DESCRIPTION
"print" is incorrect but not caught as error messages in the bmk files are ignored there.
Also the "opts" replaced stuff in "cc_opts" incorrectly.

While ":find()" can return Null, ":gsub" simply returns self even if nothing was changed